### PR TITLE
src: fix NULL pointer dereference

### DIFF
--- a/src/async.cc
+++ b/src/async.cc
@@ -15,6 +15,7 @@ void async_propagate(uv_async_t *async) {
   cnt = CFArrayGetCount(fse->events);
   for (idx=0; idx<cnt; idx++) {
     event = (fse_event *)CFArrayGetValueAtIndex(fse->events, idx);
+    if (event == NULL) continue;
     pathptr = CFStringGetCStringPtr(event->path, kCFStringEncodingUTF8);
     if (!pathptr) CFStringGetCString(event->path, pathbuf, 1024, kCFStringEncodingUTF8);
     fse->emitEvent(pathptr ? pathptr : pathbuf, event->flags, event->id);

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -11,6 +11,7 @@ struct fse_event {
 typedef struct fse_event fse_event;
 
 const void * FSEventRetain(CFAllocatorRef allocator, const void * ptr) {
+  if (ptr == NULL) return NULL;
   fse_event * orig = (fse_event * ) ptr;
   fse_event * copy = (fse_event * ) CFAllocatorAllocate(allocator, sizeof(fse_event), 0);
   copy->id = orig->id;
@@ -20,6 +21,7 @@ const void * FSEventRetain(CFAllocatorRef allocator, const void * ptr) {
   return copy;
 }
 void FSEventRelease(CFAllocatorRef allocator, const void * ptr) {
+  if (ptr == NULL) return;
   fse_event * evt = (fse_event * ) ptr;
   CFRelease(evt->path);
   CFAllocatorDeallocate(allocator, evt);


### PR DESCRIPTION
Calls to CFArrayRemoveAllValues() cause the CFArrayCallBacks retain
callback to get called with a NULL element pointer.  Bail out early
when that happens.

Fixes: https://github.com/strongloop/fsevents/issues/52

R=@es128 @bajtos