### PR TITLE
Remove travis multi-os configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
-language: c
-
-os:
-  - osx
+language: objective-c
 
 env:
   - NODE_VERSION="v0.10"


### PR DESCRIPTION
Multi OS support is a beta product and as a result it has to be requested and enabled for specific repositories. This makes it difficult for a user when they fork with the intention of submitting a PR. This change removes this dependency & instead just sets language to objective-c as this will ensure that an osx environment is used and since fsevents needs an osx environment and no other this results in the same behaviour.