### PR TITLE
Support for node-pre-gyp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
   global:
     - secure: "gve1nkeKkwFEG1VAT3i+JwYyAdF0gKXwKx0uxbkBTsmm2M+0MDusohQdFLoEIkSIFktXBIDefoa7iGpLKRfG2VsZLpwJgnvnD0HqbnuR+k+W+bu7BHt4CAaR6GTllsDCjyq9zNyhUThzSnf2WNIpOEF5kHspZlbGfawURuUJH/U="
     - secure: "jqVpmWxxBVXu2X8+XJMpKH0cooc2EKz9xKL2znBfYdNafJORSXcFAVbjCX5mZmVDcgIMwDtm2+gIG4P73hzJ2e3S+y2Z9ROJGyXHa3AxUTvXHQsxqzH8coHHqB8vTvfr0t2O5aKfpvpICpSea39r0hzNoMv6Ie5SwBdqj1YY9K0="
-matrix:
+  matrix:
     - NODE_VERSION="v0.10"
     - NODE_VERSION="v0.12"
     - NODE_VERSION="iojs-v1.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,7 +59,6 @@ before_script:
 
   - if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=true; fi;       # a
   - if test "${COMMIT_MESSAGE#*'[publish binary]'}" != "$COMMIT_MESSAGE"; then PUBLISH_BINARY=true; fi; # b
-  - if [[ NODE_VERSION == "v0.11" ]]; then PUBLISH_BINARY=false; fi;                                    # c
 
   # package & publish
   # ------------------------

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ language: objective-c
 
 env:
   global:
-    - secure: f4hgPmIW9fXvgomICcfe7vjJY3TFzALboVq1Nz9xrX1T25oIt7+rHd8CjPbBZvkSgSBY3zDItY5n47kAbWoFZGqmWF9K26WEnljPLab4QeLmy7GGZ7/jCTyashPucc34b5SC2SuXAMbDSSbEImguY27GQmeCnRqpDOS7kDVGZEU=
-    - secure: oSMNhXFS6Cb9GLlYaFhqABWDLYcagkz6KY5T6jFzJ6tCLhBSVbdSX9p0RhOBcIV7vZ2WW12Nbl9DTtUgccuQJWZaI504KBq2dD94R54h4hY5ZDymsRLqNZ71fD/gh3dhV9ukciHaPYPK2/N1OSxDSUAeBsZtPJxOprOH07iUNpQ=
-  matrix:
+    - secure: "gve1nkeKkwFEG1VAT3i+JwYyAdF0gKXwKx0uxbkBTsmm2M+0MDusohQdFLoEIkSIFktXBIDefoa7iGpLKRfG2VsZLpwJgnvnD0HqbnuR+k+W+bu7BHt4CAaR6GTllsDCjyq9zNyhUThzSnf2WNIpOEF5kHspZlbGfawURuUJH/U="
+    - secure: "jqVpmWxxBVXu2X8+XJMpKH0cooc2EKz9xKL2znBfYdNafJORSXcFAVbjCX5mZmVDcgIMwDtm2+gIG4P73hzJ2e3S+y2Z9ROJGyXHa3AxUTvXHQsxqzH8coHHqB8vTvfr0t2O5aKfpvpICpSea39r0hzNoMv6Ie5SwBdqj1YY9K0="
+matrix:
     - NODE_VERSION="v0.10"
     - NODE_VERSION="v0.12"
     - NODE_VERSION="iojs-v1.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,29 @@
-language: c
-
-os:
-  - osx
+language: objective-c
 
 env:
-  - NODE_VERSION="v0.10"
-  - NODE_VERSION="v0.11"
-  - NODE_VERSION="iojs-v1.0"
+  global:
+    - secure: f4hgPmIW9fXvgomICcfe7vjJY3TFzALboVq1Nz9xrX1T25oIt7+rHd8CjPbBZvkSgSBY3zDItY5n47kAbWoFZGqmWF9K26WEnljPLab4QeLmy7GGZ7/jCTyashPucc34b5SC2SuXAMbDSSbEImguY27GQmeCnRqpDOS7kDVGZEU=
+    - secure: oSMNhXFS6Cb9GLlYaFhqABWDLYcagkz6KY5T6jFzJ6tCLhBSVbdSX9p0RhOBcIV7vZ2WW12Nbl9DTtUgccuQJWZaI504KBq2dD94R54h4hY5ZDymsRLqNZ71fD/gh3dhV9ukciHaPYPK2/N1OSxDSUAeBsZtPJxOprOH07iUNpQ=
+  matrix:
+    - NODE_VERSION="v0.10"
+    - NODE_VERSION="v0.11"
+    - NODE_VERSION="v0.12"
+    - NODE_VERSION="iojs-v1.0"
 
 before_install:
+
   - echo $TRAVIS_OS_NAME
+
+  # commit
+  # ------------------------
+  # The commit message is used to determine the whether to manually
+  # invoke a binary publish
+
+  - COMMIT_MESSAGE=$(git show -s --format=%B $TRAVIS_COMMIT | tr -d '\n')
+
+  # node
+  # ------------------------
+
   - export PATH=./node_modules/.bin/:$PATH
   - rm -rf ~/.nvm && git clone --depth 1 https://github.com/creationix/nvm.git ~/.nvm
   - source ~/.nvm/nvm.sh
@@ -19,8 +33,67 @@ before_install:
   - npm --version
   - nvm --version
 
+  # publish dependencies
+  # ------------------------
+
+  - npm install node-gyp -g
+  - npm install aws-sdk
+
 install:
-  - npm install
+
+  # in the first instance we build from source to create the initial binary
+  # which can then be used to create a package
+
+  - npm install --build-from-source
+  - npm test
+
+before_script:
+
+  # Detemine if a publish is required.
+  #
+  # a) we are building a tag
+  # b) we put [publish binary] in the commit message
+  # c) we are not publishing if node 0.11 as it shares the same NODE_MODULE_VERSION as 12
+
+  - PUBLISH_BINARY=false
+
+  - if [[ $TRAVIS_BRANCH == `git describe --tags --always HEAD` ]]; then PUBLISH_BINARY=true; fi;       # a
+  - if test "${COMMIT_MESSAGE#*'[publish binary]'}" != "$COMMIT_MESSAGE"; then PUBLISH_BINARY=true; fi; # b
+  - if [[ NODE_VERSION == "v0.11" ]]; then PUBLISH_BINARY=false; fi;                                    # c
+
+  # package & publish
+  # ------------------------
+
+  - if [[ $PUBLISH_BINARY == true ]]; then node-pre-gyp package publish; fi;
+
+  # clean-up
+  # ------------------------
+
+  - node-pre-gyp clean
+  - node-gyp clean
 
 script:
-  - npm test
+
+  # validate
+  # ------------------------
+  # Post publishing a release verify that installing will pull down latest
+  # binary from remote host
+
+  - INSTALL_RESULT=0
+  - if [[ $PUBLISH_BINARY == true ]]; then INSTALL_RESULT=$(npm install --fallback-to-build=false > /dev/null)$? || true; fi;
+
+  - node-pre-gyp clean
+
+  # failure?
+  # ------------------------
+  # if install returned non zero (errored) then we first unpublish and then
+  # call false so travis will bail at this line.
+
+  - if [[ $INSTALL_RESULT != 0 ]]; then node-pre-gyp unpublish; fi;
+  - if [[ $INSTALL_RESULT != 0 ]]; then echo "returned $INSTALL_RESULT";false; fi;
+
+after_success:
+
+  # display all published binaries
+
+ - node-pre-gyp info

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ before_script:
   #
   # a) we are building a tag
   # b) we put [publish binary] in the commit message
-  # c) we are not publishing if node 0.11 as it shares the same NODE_MODULE_VERSION as 12
 
   - PUBLISH_BINARY=false
 

--- a/Readme.md
+++ b/Readme.md
@@ -8,10 +8,10 @@
 
 ## Installation
 
-	$ npm install -g node-gyp
+	$ npm install -g node-pre-gyp
 	$	git clone https://github.com/pipobscure/fsevents.git fsevents
 	$ cd fsevents
-	$ node-gyp configure build
+	$ node-pre-gyp configure build
 
 OR SIMPLY
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,31 +1,29 @@
 {
-  "targets": [{
-    "target_name": ""
-  }],
+  "targets": [
+    { "target_name": "" }
+  ],
   "conditions": [
     ['OS=="mac"', {
       "targets": [{
-          "target_name": "<(module_name)",
-          "sources": ["fsevents.cc"],
-          "xcode_settings": {
-            "OTHER_LDFLAGS": [
-              "-framework CoreFoundation -framework CoreServices"
-            ]
-          },
-          "include_dirs": [
-            "<!(node -e \"require('nan')\")"
+        "target_name": "<(module_name)",
+        "sources": ["fsevents.cc"],
+        "xcode_settings": {
+          "OTHER_LDFLAGS": [
+            "-framework CoreFoundation -framework CoreServices"
           ]
-        }, {
-          "target_name": "action_after_build",
-          "type": "none",
-          "dependencies": ["<(module_name)"],
-          "copies": [{
-            "files": ["<(PRODUCT_DIR)/<(module_name).node"],
-            "destination": "<(module_path)"
-          }]
-        }
-
-      ]
+        },
+        "include_dirs": [
+          "<!(node -e \"require('nan')\")"
+        ]
+      }, {
+        "target_name": "action_after_build",
+        "type": "none",
+        "dependencies": ["<(module_name)"],
+        "copies": [{
+          "files": ["<(PRODUCT_DIR)/<(module_name).node"],
+          "destination": "<(module_path)"
+        }]
+      }]
     }]
   ]
 }

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,21 +1,31 @@
 {
-  "targets": [
-    { "target_name": "" }
-  ],
+  "targets": [{
+    "target_name": ""
+  }],
   "conditions": [
     ['OS=="mac"', {
       "targets": [{
-        "target_name": "fse",
-        "sources": ["fsevents.cc"],
-        "xcode_settings": {
-          "OTHER_LDFLAGS": [
-            "-framework CoreFoundation -framework CoreServices"
+          "target_name": "<(module_name)",
+          "sources": ["fsevents.cc"],
+          "xcode_settings": {
+            "OTHER_LDFLAGS": [
+              "-framework CoreFoundation -framework CoreServices"
+            ]
+          },
+          "include_dirs": [
+            "<!(node -e \"require('nan')\")"
           ]
-        },
-        "include_dirs": [
-          "<!(node -e \"require('nan')\")"
-        ]
-      }]
+        }, {
+          "target_name": "action_after_build",
+          "type": "none",
+          "dependencies": ["<(module_name)"],
+          "copies": [{
+            "files": ["<(PRODUCT_DIR)/<(module_name).node"],
+            "destination": "<(module_path)"
+          }]
+        }
+
+      ]
     }]
   ]
 }

--- a/fsevents.js
+++ b/fsevents.js
@@ -6,10 +6,9 @@
 /* jshint node:true */
 'use strict';
 
-var binary = require('node-pre-gyp');
 var path = require('path');
-var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
-var Native = require(binding_path);
+var binary = require('node-pre-gyp');
+var Native = require(binary.find(path.join(__dirname, 'package.json')));
 
 var EventEmitter = require('events').EventEmitter;
 var fs = require('fs');

--- a/fsevents.js
+++ b/fsevents.js
@@ -6,7 +6,11 @@
 /* jshint node:true */
 'use strict';
 
-var Native = require('./build/Release/fse');
+var binary = require('node-pre-gyp');
+var path = require('path');
+var binding_path = binary.find(path.resolve(path.join(__dirname,'./package.json')));
+var Native = require(binding_path);
+
 var EventEmitter = require('events').EventEmitter;
 var fs = require('fs');
 var inherits = require('util').inherits;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Native Access to Mac OS-X FSEvents",
   "main": "fsevents.js",
   "dependencies": {
-    "nan": "~1.5.0"
+    "nan": "~1.5.0",
+    "node-pre-gyp": "^0.5.31"
   },
   "os": [
     "darwin"
@@ -13,8 +14,15 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "install": "node-gyp rebuild",
+    "install": "node-pre-gyp install --fallback-to-build",
     "test": "export PATH=$PATH:`pwd`/node_nodules/.bin/ && tap ./test"
+  },
+  "binary": {
+    "module_name" : "fse",
+    "module_path" : "./lib/binding/{configuration}/{node_abi}-{platform}-{arch}/",
+    "remote_path" : "./v{version}/",
+    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz",
+    "host"        : "https://fsevents-binary.s3.amazonaws.com"
   },
   "repository": {
     "type": "git",
@@ -31,6 +39,9 @@
     "url": "https://github.com/pipobscure/fsevents/issues"
   },
   "homepage": "https://github.com/pipobscure/fsevents",
+  "bundledDependencies": [
+    "node-pre-gyp"
+  ],
   "devDependencies": {
     "tap": "~0.4.8"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "fsevents.js",
   "dependencies": {
     "nan": "~1.5.0",
-    "node-pre-gyp": "^0.5.31"
+    "node-pre-gyp": "^0.6.4"
   },
   "os": [
     "darwin"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "module_path" : "./lib/binding/{configuration}/{node_abi}-{platform}-{arch}/",
     "remote_path" : "./v{version}/",
     "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz",
-    "host"        : "https://fsevents-binary.s3.amazonaws.com"
+    "host"        : "https://fsevents-binaries.s3-us-west-2.amazonaws.com"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This change introduces node-pre-gyp which removes the need for end users to compile when installing fsevents. This means faster installs.

## Publishing a binary
There are 2 possible ways in which a binary can published.

### Locally
```bash
> node-pre-gyp rebuild
> node-pre-gyp package
> node-pre-gyp publish
```
### Travis

#### via a tag
When a new tag is created, as part of the travis build a binary will be created and published to a remote s3 bucket.

#### via a custom commit message
Specifying [publish binary] in the commit message will publish a binary if it has not already been published.

```bash
> git commit --allow-empty -m "[publish binary]"
> git push
```
## Binary Hosting
This is presently facilitated using s3. I am using a free-tier account for the purpose of testing this change end-to-end. If this change is to be accepted then the test s3 endpoint should be switched to one under Strongloop's control.

### Changing s3 hosting
The settings for s3 are managed in two places. Package.json & .travis.yaml

#### Package.json

```javascript
  "binary": {
    ... ...
    "host"        : "https://fsevents-binary.s3.amazonaws.com"
  },
```
Replace the host parameter with a non-test endpoint.

#### .travis.yaml
Encrypted amazon keys are stored in this file and are used by node-pre-gyp for publishing. 

```bash
> gem install travis
> travis encrypt node_pre_gyp_accessKeyId="<key>"  
> travis encrypt node_pre_gyp_secretAccessKey="<secret-key>"
```
These values should replace.

```yaml
env:
  global:
    - secure:  ........
    - secure:  ........
```
## node version

As part of this change I also introduced node 0.12.0. This was intentional in order to test the scenario when a version of node may share the same "NODE_MODULE_VERSION". Presently later versions of 0.11 share the same value as 0.12, which is 14. In this instance node-pre-gyp will use the node version for the package name.
