### PR TITLE
Remove duplicative lifecycle script

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "install": "node-gyp rebuild",
-    "test": "export PATH=$PATH:`pwd`/node_nodules/.bin/ && tap ./test"
+    "test": "tap ./test"
   },
   "repository": {
     "type": "git",
@@ -26,7 +25,6 @@
   ],
   "author": "Philipp Dunkel <pip@pipobscure.com>",
   "license": "MIT",
-  "gypfile": true,
   "bugs": {
     "url": "https://github.com/strongloop/fsevents/issues"
   },


### PR DESCRIPTION
the 'install' lifecycle script is run too often; any `npm install` will trigger this rebuild, causing a lot of extra noise. Instead, the automatic support for `node-gyp` in npm should be used, and `npm rebuild` in the case of switching node versions or architectures.