### PR TITLE
json -> js code block in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -40,7 +40,7 @@ watcher.stop()  // To end observation
 
 All events except *fsevent* take an *info* object as the second parameter of the callback. The structure of this object is:
 
-```json
+```js
 {
   "event": "<event-type>",
   "id": <eventi-id>,


### PR DESCRIPTION
`json` code block highlighted comments as errors, changed language to `js` for better readability.