### PR TITLE
Use vector instead of CFMutableArray; fix #52

### DIFF
--- a/fsevents.cc
+++ b/fsevents.cc
@@ -10,6 +10,7 @@
 #include "CoreFoundation/CoreFoundation.h"
 #include "CoreServices/CoreServices.h"
 #include <iostream>
+#include <vector>
 
 #include "src/storage.cc"
 namespace fse {
@@ -45,7 +46,7 @@ namespace fse {
 
     // Common
     CFArrayRef paths;
-    CFMutableArrayRef events;
+    std::vector<fse_event*> events;
     static void Initialize(v8::Handle<v8::Object> exports);
 
     // methods.cc - exposed
@@ -61,7 +62,6 @@ using namespace fse;
 FSEvents::FSEvents(const char *path, NanCallback *handler): handler(handler) {
   CFStringRef dirs[] = { CFStringCreateWithCString(NULL, path, kCFStringEncodingUTF8) };
   paths = CFArrayCreate(NULL, (const void **)&dirs, 1, NULL);
-  events = CFArrayCreateMutable(NULL, 0,  &FSEventArrayCallBacks);
   threadloop = NULL;
   lockingStart();
 }
@@ -72,7 +72,6 @@ FSEvents::~FSEvents() {
   handler = NULL;
 
   CFRelease(paths);
-  CFRelease(events);
 }
 
 #ifndef kFSEventStreamEventFlagItemCreated

--- a/src/async.cc
+++ b/src/async.cc
@@ -12,15 +12,16 @@ void async_propagate(uv_async_t *async) {
   char pathbuf[1024];
   const char *pathptr = NULL;
   fse->lock();
-  cnt = CFArrayGetCount(fse->events);
+  cnt = fse->events.size();
   for (idx=0; idx<cnt; idx++) {
-    event = (fse_event *)CFArrayGetValueAtIndex(fse->events, idx);
+    event = fse->events.at(idx);
     if (event == NULL) continue;
     pathptr = CFStringGetCStringPtr(event->path, kCFStringEncodingUTF8);
     if (!pathptr) CFStringGetCString(event->path, pathbuf, 1024, kCFStringEncodingUTF8);
     fse->emitEvent(pathptr ? pathptr : pathbuf, event->flags, event->id);
+    delete event;
   }
-  if (cnt>0) CFArrayRemoveAllValues(fse->events);
+  if (cnt>0) fse->events.clear();
   fse->unlock();
 }
 

--- a/src/storage.cc
+++ b/src/storage.cc
@@ -7,25 +7,21 @@ struct fse_event {
   UInt64 id;
   UInt32 flags;
   CFStringRef path;
-};
-typedef struct fse_event fse_event;
+  
+  fse_event(CFStringRef eventPath, UInt32 eventFlag, UInt64 eventId) {
+    this->path = eventPath;
+    this->flags = eventFlag;
+    this->id = eventId;
+    if (this->path != NULL)
+      CFRetain(this->path);
+  }
+  
+  ~fse_event() {
+    if (this->path != NULL)
+      CFRelease(this->path);
+  }
 
-const void * FSEventRetain(CFAllocatorRef allocator, const void * ptr) {
-  if (ptr == NULL) return NULL;
-  fse_event * orig = (fse_event * ) ptr;
-  fse_event * copy = (fse_event * ) CFAllocatorAllocate(allocator, sizeof(fse_event), 0);
-  copy->id = orig->id;
-  copy->flags = orig->flags;
-  copy->path = orig->path;
-  CFRetain(copy->path);
-  return copy;
-}
-void FSEventRelease(CFAllocatorRef allocator, const void * ptr) {
-  if (ptr == NULL) return;
-  fse_event * evt = (fse_event * ) ptr;
-  CFRelease(evt->path);
-  CFAllocatorDeallocate(allocator, evt);
-}
-const CFArrayCallBacks FSEventArrayCallBacks = {
-  0, FSEventRetain, FSEventRelease, 0, 0
+private:
+  fse_event(const fse_event&);
+  void operator=(const fse_event&);
 };

--- a/src/thread.cc
+++ b/src/thread.cc
@@ -37,12 +37,13 @@ void HandleStreamEvents(ConstFSEventStreamRef stream, void *ctx, size_t numEvent
   FSEvents * fse = (FSEvents *)ctx;
   size_t idx;
   fse->lock();
-  fse_event event;
   for (idx=0; idx < numEvents; idx++) {
-    event.path = (CFStringRef)CFArrayGetValueAtIndex((CFArrayRef)eventPaths, idx);
-    event.flags = eventFlags[idx];
-    event.id = eventIds[idx];
-    CFArrayAppendValue(fse->events, &event);
+    fse_event *event = new fse_event(
+        (CFStringRef)CFArrayGetValueAtIndex((CFArrayRef)eventPaths, idx),
+        eventFlags[idx],
+        eventIds[idx]
+      );
+    fse->events.push_back(event);
   }
   fse->asyncTrigger();
   fse->unlock();


### PR DESCRIPTION
It was observed from the core dump file that the crash occurred at `__CFArrayReleaseValues` of `CFArrayRemoveAllValues`. Analysis shows that when large number of items were added to a CFMutableArray, resizing of the container occurred. The resizing lead to `FSEventRelease` being prematurely called, causing the crash.

Therefore we store pointers in a plain vector to solve this problem.