### PR TITLE
Add io.js 3.0 to Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
   - NODE_VERSION="v0.12"
   - NODE_VERSION="iojs-v1.0"
   - NODE_VERSION="iojs-v2.0"
+  - NODE_VERSION="iojs-v3.0"
 
 before_install:
   - echo $TRAVIS_OS_NAME


### PR DESCRIPTION
io.js v3.0 was released at 2015-08-04. https://github.com/nodejs/io.js/blob/master/CHANGELOG.md#2015-08-04-version-300-rvagg
