### PR TITLE
Add lib/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build/
 node_modules/
+lib/


### PR DESCRIPTION
The pre-gyp addition introduces a `lib` dir that should not be checked in