### PR TITLE
Ensure bundled dependencies are staged cleanly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
   - source ~/.nvm/nvm.sh
   - nvm install $NODE_VERSION
   - nvm use $NODE_VERSION
+  - npm install -g npm@latest
   - node --version
   - npm --version
   - nvm --version

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "install": "node-pre-gyp install --fallback-to-build",
+    "prepublish": "if [ $(npm -v | head -c 1) -lt 3 ]; then exit 1; fi && npm dedupe",
     "test": "tap ./test"
   },
   "binary": {


### PR DESCRIPTION
Resolves #97 by enforcing use of npm3+ for publishing and ensuring deps are flattened. `npm dedupe` needs to be run explicitly since node-pre-gyp bundles its own non-flattened deps.

Used `npm pack` to try to make sure this would remain compatible with older versions of npm/node, and it appears so. But it's hard to have 100% certainty about it without actually publishing to the npm registry and trying from there.