### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "fsevents.js",
   "dependencies": {
     "nan": "^2.0.2",
-    "node-pre-gyp": "^0.6.14"
+    "node-pre-gyp": "^0.6.15"
   },
   "os": [
     "darwin"


### PR DESCRIPTION
NSP check is preventing me from deploying my latest because this module relies on a version of node-pre-gyp which relied on a version of tar-pack that relies on a vulnerable version of tar.

From https://nodesecurity.io/advisories/57:

    The tar module earlier than version 2.0.0 allow for archives to
    contain symbolic links that will overwrite targets outside the
    expected path for extraction.