### PR TITLE
Don't use deprecated v8::Template::Set().

### DIFF
--- a/fsevents.cc
+++ b/fsevents.cc
@@ -90,10 +90,10 @@ void FSEvents::Initialize(v8::Handle<v8::Object> exports) {
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   tpl->PrototypeTemplate()->Set(
            Nan::New<v8::String>("start").ToLocalChecked(),
-           Nan::New<v8::FunctionTemplate>(FSEvents::Start)->GetFunction());
+           Nan::New<v8::FunctionTemplate>(FSEvents::Start));
   tpl->PrototypeTemplate()->Set(
            Nan::New<v8::String>("stop").ToLocalChecked(),
-           Nan::New<v8::FunctionTemplate>(FSEvents::Stop)->GetFunction());
+           Nan::New<v8::FunctionTemplate>(FSEvents::Stop));
   exports->Set(Nan::New<v8::String>("Constants").ToLocalChecked(), Constants());
   exports->Set(Nan::New<v8::String>("FSEvents").ToLocalChecked(),
                tpl->GetFunction());

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Native Access to Mac OS-X FSEvents",
   "main": "fsevents.js",
   "dependencies": {
-    "nan": "^2.1.0",
+    "nan": "^2.3.0",
     "node-pre-gyp": "^0.6.25"
   },
   "os": [


### PR DESCRIPTION
See [0] and [1]: starting with node.js v6, setting non-primitive values
on FunctionTemplate and ObjectTemplate instances is discouraged; v7 will
downright disallow it.  Update the code base.

[0] https://github.com/nodejs/node/issues/6216
[1] https://github.com/nodejs/node/pull/6228

Refs: https://github.com/strongloop/fsevents/issues/127