### PR TITLE
Add Windows OS as blacklisted

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node-pre-gyp": "^0.6.29"
   },
   "os": [
-    "darwin"
+    "darwin", "!win32"
   ],
   "engines": {
     "node": ">=0.8.0"


### PR DESCRIPTION
`npm WARN notsup Not compatible with your operating system or architecture: fsevents@1.0.14`
https://github.com/karma-runner/karma/issues/2347
https://github.com/paulmillr/chokidar/issues/529