### PR TITLE
install: better win, linux install experience

### DIFF
--- a/fsevents.js
+++ b/fsevents.js
@@ -6,10 +6,10 @@
 /* jshint node:true */
 'use strict';
 
-if(process.platform !== 'darwin') {
-  var err = new Error("Cannot find module 'fsevents'")
-  err.code = 'MODULE_NOT_FOUND'
-  throw err
+if (process.platform !== 'darwin') {
+  var err = new Error('Cannot find module \'fsevents\'');
+  err.code = 'MODULE_NOT_FOUND';
+  throw err;
 }
 
 

--- a/fsevents.js
+++ b/fsevents.js
@@ -6,12 +6,8 @@
 /* jshint node:true */
 'use strict';
 
-if (process.platform !== 'darwin') {
-  var err = new Error('Cannot find module \'fsevents\'');
-  err.code = 'MODULE_NOT_FOUND';
-  throw err;
-}
-
+if (process.platform !== 'darwin')
+  throw new Error('Module \'fsevents\' is not compatible with platform \'' + process.platform + '\'');
 
 var path = require('path');
 var binary = require('node-pre-gyp');

--- a/fsevents.js
+++ b/fsevents.js
@@ -6,6 +6,13 @@
 /* jshint node:true */
 'use strict';
 
+if(process.platform !== 'darwin') {
+  var err = new Error("Cannot find module 'fsevents'")
+  err.code = 'MODULE_NOT_FOUND'
+  throw err
+}
+
+
 var path = require('path');
 var binary = require('node-pre-gyp');
 var Native = require(binary.find(path.join(__dirname, 'package.json')));

--- a/install.js
+++ b/install.js
@@ -1,0 +1,5 @@
+if (process.platform === 'darwin') {
+  var spawn = require('child_process').spawn;
+  var child = spawn('node-pre-gyp', ['install', '--fallback-to-build'], {stdio: 'inherit'});
+  child.on('close', function(code) {process.exit(code)});
+}

--- a/install.js
+++ b/install.js
@@ -1,5 +1,7 @@
 if (process.platform === 'darwin') {
   var spawn = require('child_process').spawn;
-  var child = spawn('node-pre-gyp', ['install', '--fallback-to-build'], {stdio: 'inherit'});
-  child.on('close', function(code) {process.exit(code)});
+  var args = ['install', '--fallback-to-build'];
+  var options = {stdio: 'inherit'};
+  var child = spawn('node-pre-gyp', args, options);
+  child.on('close', process.exit);
 }

--- a/package.json
+++ b/package.json
@@ -1,21 +1,18 @@
 {
   "name": "fsevents",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Native Access to Mac OS-X FSEvents",
   "main": "fsevents.js",
   "dependencies": {
     "nan": "^2.3.0",
     "node-pre-gyp": "^0.6.29"
   },
-  "os": [
-    "darwin"
-  ],
   "engines": {
     "node": ">=0.8.0"
   },
   "scripts": {
-    "install": "node-pre-gyp install --fallback-to-build",
-    "prepublish": "if [ $(npm -v | head -c 1) -lt 3 ]; then exit 1; fi && npm dedupe",
+    "install": "node -e \"process.platform==='darwin' && require('child_process').execSync('node-pre-gyp install --fallback-to-build')\"",
+    "prepublish": "node -e \"process.platform==='darwin' && require('child_process').execSync('if [ $(npm -v | head -c 1) -lt 3 ]; then exit 1; fi && npm dedupe')\"",
     "test": "tap ./test"
   },
   "binary": {

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "node": ">=0.8.0"
   },
   "scripts": {
-    "install": "node -e \"process.platform==='darwin' && require('child_process').execSync('node-pre-gyp install --fallback-to-build')\"",
-    "prepublish": "node -e \"process.platform==='darwin' && require('child_process').execSync('if [ $(npm -v | head -c 1) -lt 3 ]; then exit 1; fi && npm dedupe')\"",
+    "install": "node install",
+    "prepublish": "if [ $(npm -v | head -c 1) -lt 3 ]; then exit 1; fi && npm dedupe",
     "test": "tap ./test"
   },
   "binary": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsevents",
-  "version": "1.0.18",
+  "version": "1.0.17",
   "description": "Native Access to Mac OS-X FSEvents",
   "main": "fsevents.js",
   "dependencies": {


### PR DESCRIPTION
eliminate platform warning when npm, yarn, etc
attempt to install on non darwin systems. this is
achieved by always installing, but artificially throwing
"Cannot find module 'fsevents'" when require()d
by dependents running on non darwin platform.

npm scripts entries also updated to bypass node-pre-gyp, etc.
when running on non darwin platform.