### PR TITLE
Use require.resolve to resolve node-pre-gyp

### DIFF
--- a/install.js
+++ b/install.js
@@ -2,6 +2,6 @@ if (process.platform === 'darwin') {
   var spawn = require('child_process').spawn;
   var args = ['install', '--fallback-to-build'];
   var options = {stdio: 'inherit'};
-  var child = spawn('node-pre-gyp', args, options);
+  var child = spawn(require.resolve('node-pre-gyp/bin/node-pre-gyp'), args, options);
   child.on('close', process.exit);
 }


### PR DESCRIPTION
Fixes #176 

Using `require.resolve` is better option to resolve module path because when installing fsevents with `npm install --no-bin-links fsevents` `spawn` can not find `node-pre-gyp` in `PATH`. If we use relative path `./node_modules/node-pre-gyp/bin/node-pre-gyp` in `spawn` call then this will error in case when packages are deduped and `node-pre-gyp` is located upper in file system tree.

Also see https://github.com/npm/npm/issues/10095