### PR TITLE
Bump node-pre-gyp to 0.6.39

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "fsevents.js",
   "dependencies": {
     "nan": "^2.3.0",
-    "node-pre-gyp": "^0.6.36"
+    "node-pre-gyp": "^0.6.39"
   },
   "os": [
     "darwin"


### PR DESCRIPTION
According to [node-pre-gyp's changelog](https://github.com/mapbox/node-pre-gyp/blob/master/CHANGELOG.md), this will also be necessary for node v9 support.

We can't rely on semver ranges because of the dependency bundling.