### PR TITLE
fix: propagate async context

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
     - NODE_VERSION="v6"
     - NODE_VERSION="v5"
     - NODE_VERSION="v4"
-    - NODE_VERSION="v0.12"
     - NODE_VERSION="v0.10"
 
 before_install:

--- a/fsevents.cc
+++ b/fsevents.cc
@@ -41,6 +41,7 @@ namespace fse {
     void threadStop();
 
     // methods.cc - internal
+    Nan::AsyncResource async_resource;
     Nan::Callback *handler;
     void emitEvent(const char *path, UInt32 flags, UInt64 id);
 
@@ -59,7 +60,8 @@ namespace fse {
 
 using namespace fse;
 
-FSEvents::FSEvents(const char *path, Nan::Callback *handler): handler(handler) {
+FSEvents::FSEvents(const char *path, Nan::Callback *handler)
+    : async_resource("fsevents:FSEvents"), handler(handler) {
   CFStringRef dirs[] = { CFStringCreateWithCString(NULL, path, kCFStringEncodingUTF8) };
   paths = CFArrayCreate(NULL, (const void **)&dirs, 1, NULL);
   threadloop = NULL;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Native Access to Mac OS-X FSEvents",
   "main": "fsevents.js",
   "dependencies": {
-    "nan": "^2.3.0",
+    "nan": "^2.9.2",
     "node-pre-gyp": "^0.6.39"
   },
   "os": [

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -11,7 +11,7 @@ void FSEvents::emitEvent(const char *path, UInt32 flags, UInt64 id) {
     Nan::New<v8::Number>(flags),
     Nan::New<v8::Number>(id)
   };
-  handler->Call(3, argv);
+  handler->Call(3, argv, &async_resource);
 }
 
 NAN_METHOD(FSEvents::New) {


### PR DESCRIPTION
Start with Nan 2.9.0 certain variants of `Nan::Callback::Call` are
deprecated. Overloads that preserve the async context are preferred
instead.

We associate a `Nan::AsyncResource` corresponding to a FSEvents instance.
This captures the async execution context which is restored when the
async callback is called.

For more information see https://github.com/nodejs/nan/blob/HEAD/doc/node_misc.md#nanasyncresource.

EDIT: this fixes the compile warnings that are presently displayed:
```
In file included from ../fsevents.cc:85:
../src/methods.cc:14:12: warning: 'Call' is deprecated [-Wdeprecated-declarations]
  handler->Call(3, argv);
           ^
```