### PR TITLE
fix: possible SIGILL and memory leak

### DIFF
--- a/fsevents.cc
+++ b/fsevents.cc
@@ -16,7 +16,7 @@
 namespace fse {
   class FSEvents : public node::ObjectWrap {
   public:
-    FSEvents(const char *path, Nan::Callback *handler);
+    FSEvents(const char *path);
     ~FSEvents();
 
     // locking.cc
@@ -42,7 +42,6 @@ namespace fse {
 
     // methods.cc - internal
     Nan::AsyncResource async_resource;
-    Nan::Callback *handler;
     void emitEvent(const char *path, UInt32 flags, UInt64 id);
 
     // Common
@@ -60,18 +59,15 @@ namespace fse {
 
 using namespace fse;
 
-FSEvents::FSEvents(const char *path, Nan::Callback *handler)
-    : async_resource("fsevents:FSEvents"), handler(handler) {
+FSEvents::FSEvents(const char *path)
+   : async_resource("fsevents:FSEvents") {
   CFStringRef dirs[] = { CFStringCreateWithCString(NULL, path, kCFStringEncodingUTF8) };
   paths = CFArrayCreate(NULL, (const void **)&dirs, 1, NULL);
   threadloop = NULL;
   lockingStart();
 }
 FSEvents::~FSEvents() {
-  std::cout << "YIKES" << std::endl;
   lockingStop();
-  delete handler;
-  handler = NULL;
 
   CFRelease(paths);
 }

--- a/fsevents.cc
+++ b/fsevents.cc
@@ -20,7 +20,7 @@ namespace fse {
     ~FSEvents();
 
     // locking.cc
-    bool lockStarted;
+    bool lockStarted = false;
     pthread_mutex_t lockmutex;
     void lockingStart();
     void lock();

--- a/fsevents.cc
+++ b/fsevents.cc
@@ -14,13 +14,13 @@
 
 #include "src/storage.cc"
 namespace fse {
-  class FSEvents : public node::ObjectWrap {
+  class FSEvents : public Nan::ObjectWrap {
   public:
-    FSEvents(const char *path);
+    explicit FSEvents(const char *path);
     ~FSEvents();
 
     // locking.cc
-    bool lockStarted = false;
+    bool lockStarted;
     pthread_mutex_t lockmutex;
     void lockingStart();
     void lock();
@@ -60,7 +60,7 @@ namespace fse {
 using namespace fse;
 
 FSEvents::FSEvents(const char *path)
-   : async_resource("fsevents:FSEvents") {
+   : async_resource("fsevents:FSEvents"), lockStarted(false) {
   CFStringRef dirs[] = { CFStringCreateWithCString(NULL, path, kCFStringEncodingUTF8) };
   paths = CFArrayCreate(NULL, (const void **)&dirs, 1, NULL);
   threadloop = NULL;

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -6,7 +6,8 @@
 void FSEvents::emitEvent(const char *path, UInt32 flags, UInt64 id) {
   Nan::HandleScope handle_scope;
   v8::Local<v8::Object> object = handle();
-  Nan::Callback handler(object->Get(object->CreationContext(), Nan::New<v8::String>("handler").ToLocalChecked()).ToLocalChecked().As<v8::Function>());
+  v8::Local<v8::Value> key = Nan::New<v8::String>("handler").ToLocalChecked();
+  Nan::Callback handler(Nan::To<v8::Function>(Nan::Get(object, key).ToLocalChecked()).ToLocalChecked());
   v8::Local<v8::Value> argv[] = {
     Nan::New<v8::String>(path).ToLocalChecked(),
     Nan::New<v8::Number>(flags),
@@ -20,13 +21,13 @@ NAN_METHOD(FSEvents::New) {
 
   FSEvents *fse = new FSEvents(*path);
   fse->Wrap(info.This());
-  info.This()->Set(info.This()->CreationContext(), Nan::New<v8::String>("handler").ToLocalChecked(), info[1].As<v8::Function>());
+  Nan::Set(info.This(), Nan::New<v8::String>("handler").ToLocalChecked(), info[1]);
 
   info.GetReturnValue().Set(info.This());
 }
 
 NAN_METHOD(FSEvents::Stop) {
-  FSEvents* fse = node::ObjectWrap::Unwrap<FSEvents>(info.This());
+  FSEvents* fse = Nan::ObjectWrap::Unwrap<FSEvents>(info.This());
 
   fse->threadStop();
   fse->asyncStop();
@@ -35,7 +36,7 @@ NAN_METHOD(FSEvents::Stop) {
 }
 
 NAN_METHOD(FSEvents::Start) {
-  FSEvents* fse = node::ObjectWrap::Unwrap<FSEvents>(info.This());
+  FSEvents* fse = Nan::ObjectWrap::Unwrap<FSEvents>(info.This());
   fse->asyncStart();
   fse->threadStart();
 

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -4,22 +4,23 @@
 */
 
 void FSEvents::emitEvent(const char *path, UInt32 flags, UInt64 id) {
-  if (!handler) return;
   Nan::HandleScope handle_scope;
+  v8::Local<v8::Object> object = handle();
+  Nan::Callback handler(object->Get(object->CreationContext(), Nan::New<v8::String>("handler").ToLocalChecked()).ToLocalChecked().As<v8::Function>());
   v8::Local<v8::Value> argv[] = {
     Nan::New<v8::String>(path).ToLocalChecked(),
     Nan::New<v8::Number>(flags),
     Nan::New<v8::Number>(id)
   };
-  handler->Call(3, argv, &async_resource);
+  handler.Call(3, argv, &async_resource);
 }
 
 NAN_METHOD(FSEvents::New) {
-  Nan::Utf8String *path = new Nan::Utf8String(info[0]);
-  Nan::Callback *callback = new Nan::Callback(info[1].As<v8::Function>());
+  Nan::Utf8String path(info[0]);
 
-  FSEvents *fse = new FSEvents(**path, callback);
+  FSEvents *fse = new FSEvents(*path);
   fse->Wrap(info.This());
+  info.This()->Set(info.This()->CreationContext(), Nan::New<v8::String>("handler").ToLocalChecked(), info[1].As<v8::Function>());
 
   info.GetReturnValue().Set(info.This());
 }


### PR DESCRIPTION
This PR fixes two bugs which I found while "stress-testing" the library with

```javascript
var fsevents = require("fsevents");
while(true) {
  new fsevents.FSEvents("/", () => {});
}
```
and

```javascript
var fsevents = require("fsevents");
while(true) {
  fsevents("/");
}
```

The first one is a SIGILL signal generated in `pthread_mutex_destroy` because the mutex is not always initialized. This is caused by not initializing `lockStarted` which causes it to sometimes be true, depending on where the object was allocated. A simple fix is to initialize it to `false`.

The other bug is a cyclic dependency which is hidden from v8 and therefore never freed. If the closure handed to FSEvents has a reference to the event and FSEvents saves the callback internally, a cyclic dependency is created. The problem arises, because v8 can only directly see the `closure->FSEvents` dependency not the internal one. My fix is to "promote" the closure reference to the associated v8::Object, therefore allowing v8 to see the dependency. Before fixing this bug I had no prior experience with v8 so my solution might not be ideal.

In general I did not see any contribution guidelines so I would be happy to amend these changes where necessary.