### PR TITLE
[Don't merge] FSEvents on N-API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ env:
     - NODE_VERSION="v6"
     - NODE_VERSION="v5"
     - NODE_VERSION="v4"
-    - NODE_VERSION="v0.10"
 
 before_install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,8 @@ env:
     - secure: "jqVpmWxxBVXu2X8+XJMpKH0cooc2EKz9xKL2znBfYdNafJORSXcFAVbjCX5mZmVDcgIMwDtm2+gIG4P73hzJ2e3S+y2Z9ROJGyXHa3AxUTvXHQsxqzH8coHHqB8vTvfr0t2O5aKfpvpICpSea39r0hzNoMv6Ie5SwBdqj1YY9K0="
   matrix:
     - NODE_VERSION="v10"
-    - NODE_VERSION="v9"
     - NODE_VERSION="v8"
-    - NODE_VERSION="v7"
     - NODE_VERSION="v6"
-    - NODE_VERSION="v5"
-    - NODE_VERSION="v4"
 
 before_install:
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -6,6 +6,15 @@
     ['OS=="mac"', {
       "targets": [{
         "target_name": "<(module_name)",
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
         "sources": ["fsevents.cc"],
         "xcode_settings": {
           "OTHER_LDFLAGS": [
@@ -13,12 +22,22 @@
           ]
         },
         "include_dirs": [
-          "<!(node -e \"require('nan')\")"
+          "<!@(node -p \"require('node-addon-api').include\")",
         ]
       }, {
         "target_name": "action_after_build",
+      "cflags!": [ "-fno-exceptions" ],
+      "cflags_cc!": [ "-fno-exceptions" ],
+      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+        "CLANG_CXX_LIBRARY": "libc++",
+        "MACOSX_DEPLOYMENT_TARGET": "10.7",
+      },
+      "msvs_settings": {
+        "VCCLCompilerTool": { "ExceptionHandling": 1 },
+      },
         "type": "none",
-        "dependencies": ["<(module_name)"],
+        "dependencies": [
+          "<!(node -p 'require(\"node-addon-api\").gyp')","<(module_name)"],
         "copies": [{
           "files": ["<(PRODUCT_DIR)/<(module_name).node"],
           "destination": "<(module_path)"

--- a/binding.gyp
+++ b/binding.gyp
@@ -24,7 +24,10 @@
         "include_dirs": [
           "<!@(node -p \"require('node-addon-api').include\")",
         ],
-        "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
+        "defines": [
+          "NAPI_DISABLE_CPP_EXCEPTIONS",
+          "NAPI_VERSION=<(napi_build_version)",
+        ],
       }, {
         "target_name": "action_after_build",
       "cflags!": [ "-fno-exceptions" ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,7 @@
         "target_name": "<(module_name)",
       "cflags!": [ "-fno-exceptions" ],
       "cflags_cc!": [ "-fno-exceptions" ],
-      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+      "xcode_settings": {
         "CLANG_CXX_LIBRARY": "libc++",
         "MACOSX_DEPLOYMENT_TARGET": "10.7",
       },
@@ -23,12 +23,13 @@
         },
         "include_dirs": [
           "<!@(node -p \"require('node-addon-api').include\")",
-        ]
+        ],
+        "defines": [ "NAPI_DISABLE_CPP_EXCEPTIONS" ],
       }, {
         "target_name": "action_after_build",
       "cflags!": [ "-fno-exceptions" ],
       "cflags_cc!": [ "-fno-exceptions" ],
-      "xcode_settings": { "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+      "xcode_settings": {
         "CLANG_CXX_LIBRARY": "libc++",
         "MACOSX_DEPLOYMENT_TARGET": "10.7",
       },

--- a/fsevents.js
+++ b/fsevents.js
@@ -15,20 +15,29 @@ var Native = require(binary.find(path.join(__dirname, 'package.json')));
 
 var EventEmitter = require('events').EventEmitter;
 var fs = require('fs');
-var inherits = require('util').inherits;
 
-function FSEvents(path, handler) {
-  EventEmitter.call(this);
+class FSEvents extends EventEmitter {
+  constructor(path, handler) {
+    super();
+    Object.defineProperty(this, '_impl', {
+      value: new Native.FSEvents(String(path || ''), handler),
+      enumerable: false,
+      writable: false
+    });
+  }
 
-  Object.defineProperty(this, '_impl', {
-    value: new Native.FSEvents(String(path || ''), handler),
-    enumerable: false,
-    writable: false
-  });
+  start() {
+    this._impl.start();
+
+    return this;
+  }
+
+  stop() {
+    this._impl.stop();
+
+    return this;
+  }
 }
-
-inherits(FSEvents, EventEmitter);
-proxies(FSEvents, Native.FSEvents);
 
 module.exports = watch;
 module.exports.getInfo = getInfo;
@@ -57,17 +66,6 @@ function watch(path) {
       }
     });
   }
-}
-
-function proxies(ctor, target) {
-  Object.keys(target.prototype).filter(function(key) {
-    return typeof target.prototype[key] === 'function';
-  }).forEach(function(key) {
-    ctor.prototype[key] = function() {
-      this._impl[key].apply(this._impl, arguments);
-      return this;
-    }
-  });
 }
 
 function getFileType(flags) {

--- a/fsevents.js
+++ b/fsevents.js
@@ -35,15 +35,13 @@ module.exports.getInfo = getInfo;
 module.exports.FSEvents = Native.FSEvents;
 module.exports.Constants = Native.Constants;
 
-var defer = global.setImmediate || process.nextTick;
-
 function watch(path) {
   var fse = new FSEvents(String(path || ''), handler);
   EventEmitter.call(fse);
   return fse;
 
   function handler(path, flags, id) {
-    defer(function() {
+    setImmediate(function() {
       fse.emit('fsevent', path, flags, id);
       var info = getInfo(path, flags);
       info.id = id;

--- a/package.json
+++ b/package.json
@@ -21,10 +21,13 @@
   },
   "binary": {
     "module_name": "fse",
-    "module_path": "./lib/binding/{configuration}/{node_abi}-{platform}-{arch}/",
+    "module_path": "./lib/binding/{configuration}/{platform}-{arch}-napi{napi_build_version}/",
     "remote_path": "./v{version}/",
-    "package_name": "{module_name}-v{version}-{node_abi}-{platform}-{arch}.tar.gz",
-    "host": "https://fsevents-binaries.s3-us-west-2.amazonaws.com"
+    "package_name": "{module_name}-v{version}-napi{napi_build_version}-{platform}-{arch}.tar.gz",
+    "host": "https://fsevents-binaries.s3-us-west-2.amazonaws.com",
+    "napi_versions": [
+      1
+    ]
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "darwin"
   ],
   "engines": {
-    "node": ">=4"
+    "node": "^6.14.2 || ^8.12 || >=10"
   },
   "scripts": {
     "install": "node install",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "darwin"
   ],
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=4"
   },
   "scripts": {
     "install": "node install",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
   ],
   "homepage": "https://github.com/strongloop/fsevents",
   "devDependencies": {
-    "tap": "~0.4.8"
+    "tap": "^12.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Native Access to Mac OS-X FSEvents",
   "main": "fsevents.js",
   "dependencies": {
-    "nan": "^2.9.2",
+    "node-addon-api": "1.4.0",
     "node-pre-gyp": "^0.11.0"
   },
   "os": [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "fsevents.js",
   "dependencies": {
     "nan": "^2.9.2",
-    "node-pre-gyp": "^0.10.0"
+    "node-pre-gyp": "^0.11.0"
   },
   "os": [
     "darwin"

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -84,27 +84,27 @@
 #define kFSEventStreamEventFlagItemIsSymlink 0x00040000
 #endif
 
-static v8::Local<v8::Object> Constants() {
-  v8::Local<v8::Object> object = Nan::New<v8::Object>();
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagNone").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagNone));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagMustScanSubDirs").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagMustScanSubDirs));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagUserDropped").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagUserDropped));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagKernelDropped").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagKernelDropped));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagEventIdsWrapped").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagEventIdsWrapped));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagHistoryDone").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagHistoryDone));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagRootChanged").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagRootChanged));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagMount").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagMount));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagUnmount").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagUnmount));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagItemCreated").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagItemCreated));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagItemRemoved").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagItemRemoved));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagItemInodeMetaMod").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagItemInodeMetaMod));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagItemRenamed").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagItemRenamed));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagItemModified").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagItemModified));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagItemFinderInfoMod").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagItemFinderInfoMod));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagItemChangeOwner").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagItemChangeOwner));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagItemXattrMod").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagItemXattrMod));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagItemIsFile").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagItemIsFile));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagItemIsDir").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagItemIsDir));
-  object->Set(Nan::New<v8::String>("kFSEventStreamEventFlagItemIsSymlink").ToLocalChecked(), Nan::New<v8::Integer>(kFSEventStreamEventFlagItemIsSymlink));
+static Napi::Object Constants() {
+  Napi::Object object = Napi::Object::New(env);
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagNone"), Napi::Number::New(env, kFSEventStreamEventFlagNone));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagMustScanSubDirs"), Napi::Number::New(env, kFSEventStreamEventFlagMustScanSubDirs));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagUserDropped"), Napi::Number::New(env, kFSEventStreamEventFlagUserDropped));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagKernelDropped"), Napi::Number::New(env, kFSEventStreamEventFlagKernelDropped));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagEventIdsWrapped"), Napi::Number::New(env, kFSEventStreamEventFlagEventIdsWrapped));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagHistoryDone"), Napi::Number::New(env, kFSEventStreamEventFlagHistoryDone));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagRootChanged"), Napi::Number::New(env, kFSEventStreamEventFlagRootChanged));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagMount"), Napi::Number::New(env, kFSEventStreamEventFlagMount));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagUnmount"), Napi::Number::New(env, kFSEventStreamEventFlagUnmount));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagItemCreated"), Napi::Number::New(env, kFSEventStreamEventFlagItemCreated));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagItemRemoved"), Napi::Number::New(env, kFSEventStreamEventFlagItemRemoved));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagItemInodeMetaMod"), Napi::Number::New(env, kFSEventStreamEventFlagItemInodeMetaMod));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagItemRenamed"), Napi::Number::New(env, kFSEventStreamEventFlagItemRenamed));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagItemModified"), Napi::Number::New(env, kFSEventStreamEventFlagItemModified));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagItemFinderInfoMod"), Napi::Number::New(env, kFSEventStreamEventFlagItemFinderInfoMod));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagItemChangeOwner"), Napi::Number::New(env, kFSEventStreamEventFlagItemChangeOwner));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagItemXattrMod"), Napi::Number::New(env, kFSEventStreamEventFlagItemXattrMod));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagItemIsFile"), Napi::Number::New(env, kFSEventStreamEventFlagItemIsFile));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagItemIsDir"), Napi::Number::New(env, kFSEventStreamEventFlagItemIsDir));
+  object.Set(Napi::String::New(env, "kFSEventStreamEventFlagItemIsSymlink"), Napi::Number::New(env, kFSEventStreamEventFlagItemIsSymlink));
   return object;
 }

--- a/src/constants.cc
+++ b/src/constants.cc
@@ -84,7 +84,7 @@
 #define kFSEventStreamEventFlagItemIsSymlink 0x00040000
 #endif
 
-static Napi::Object Constants() {
+static Napi::Object Constants(Napi::Env env) {
   Napi::Object object = Napi::Object::New(env);
   object.Set(Napi::String::New(env, "kFSEventStreamEventFlagNone"), Napi::Number::New(env, kFSEventStreamEventFlagNone));
   object.Set(Napi::String::New(env, "kFSEventStreamEventFlagMustScanSubDirs"), Napi::Number::New(env, kFSEventStreamEventFlagMustScanSubDirs));

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -4,41 +4,41 @@
 */
 
 void FSEvents::emitEvent(const char *path, UInt32 flags, UInt64 id) {
-  Nan::HandleScope handle_scope;
-  v8::Local<v8::Object> object = handle();
-  v8::Local<v8::Value> key = Nan::New<v8::String>("handler").ToLocalChecked();
-  Nan::Callback handler(Nan::To<v8::Function>(Nan::Get(object, key).ToLocalChecked()).ToLocalChecked());
-  v8::Local<v8::Value> argv[] = {
-    Nan::New<v8::String>(path).ToLocalChecked(),
-    Nan::New<v8::Number>(flags),
-    Nan::New<v8::Number>(id)
+  Napi::HandleScope handle_scope(env);
+  Napi::Object object = handle();
+  Napi::Value key = Napi::String::New(env, "handler");
+  Napi::FunctionReference handler((object).Get(key.To<Napi::Function>()));
+  Napi::Value argv[] = {
+    Napi::String::New(env, path),
+    Napi::Number::New(env, flags),
+    Napi::Number::New(env, id)
   };
   handler.Call(3, argv, &async_resource);
 }
 
-NAN_METHOD(FSEvents::New) {
-  Nan::Utf8String path(info[0]);
+Napi::Value FSEvents::New(const Napi::CallbackInfo& info) {
+  std::string path = info[0].As<Napi::String>();
 
   FSEvents *fse = new FSEvents(*path);
   fse->Wrap(info.This());
-  Nan::Set(info.This(), Nan::New<v8::String>("handler").ToLocalChecked(), info[1]);
+  (info.This()).Set(Napi::String::New(env, "handler"), info[1]);
 
-  info.GetReturnValue().Set(info.This());
+  return info.This();
 }
 
-NAN_METHOD(FSEvents::Stop) {
-  FSEvents* fse = Nan::ObjectWrap::Unwrap<FSEvents>(info.This());
+Napi::Value FSEvents::Stop(const Napi::CallbackInfo& info) {
+  FSEvents* fse = this;
 
   fse->threadStop();
   fse->asyncStop();
 
-  info.GetReturnValue().Set(info.This());
+  return info.This();
 }
 
-NAN_METHOD(FSEvents::Start) {
-  FSEvents* fse = Nan::ObjectWrap::Unwrap<FSEvents>(info.This());
+Napi::Value FSEvents::Start(const Napi::CallbackInfo& info) {
+  FSEvents* fse = this;
   fse->asyncStart();
   fse->threadStart();
 
-  info.GetReturnValue().Set(info.This());
+  return info.This();
 }

--- a/src/methods.cc
+++ b/src/methods.cc
@@ -4,29 +4,20 @@
 */
 
 void FSEvents::emitEvent(const char *path, UInt32 flags, UInt64 id) {
-  Napi::HandleScope handle_scope(env);
-  Napi::Object object = handle();
-  Napi::Value key = Napi::String::New(env, "handler");
-  Napi::FunctionReference handler((object).Get(key.To<Napi::Function>()));
-  Napi::Value argv[] = {
+  Napi::Env env = Env();
+  Napi::HandleScope scope(env);
+
+  handler.Call(env.Undefined(), {
     Napi::String::New(env, path),
     Napi::Number::New(env, flags),
     Napi::Number::New(env, id)
-  };
-  handler.Call(3, argv, &async_resource);
-}
-
-Napi::Value FSEvents::New(const Napi::CallbackInfo& info) {
-  std::string path = info[0].As<Napi::String>();
-
-  FSEvents *fse = new FSEvents(*path);
-  fse->Wrap(info.This());
-  (info.This()).Set(Napi::String::New(env, "handler"), info[1]);
-
-  return info.This();
+  });
 }
 
 Napi::Value FSEvents::Stop(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
   FSEvents* fse = this;
 
   fse->threadStop();
@@ -36,6 +27,9 @@ Napi::Value FSEvents::Stop(const Napi::CallbackInfo& info) {
 }
 
 Napi::Value FSEvents::Start(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  Napi::HandleScope scope(env);
+
   FSEvents* fse = this;
   fse->asyncStart();
   fse->threadStart();


### PR DESCRIPTION
This is obviously not ready to merge as the list of Node.js versions where N-API works without printing a warning is tiny right now (`^6.14.2 || ^8.12 || >=10`) but I thought it'd be interesting to show what it'd look like.

Two things are really cool about this

- When updating Node.js (e.g. from 8.12 to 10) fsevents doesn't have to be rebuild or redownloaded
- Since fsevents only supports one platform with one architecture it should be easy enough to ship the compiled version on drop node-pre-gyp

Anyway, nothing actionable for now but I thought I'd share :)