### PR TITLE
Release v1.2.5 with only bundled deps upgrades

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsevents",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Native Access to Mac OS-X FSEvents",
   "main": "fsevents.js",
   "dependencies": {


### PR DESCRIPTION
As the "node-pre-gyp": "^0.10.0" are bundled just doing npm install and npm publish would upgrade the patch versions in the dependency tree which is desirable as there were some important updates there with regards to licensing.
