### PR TITLE
Update to build for node v11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ env:
     - secure: "gve1nkeKkwFEG1VAT3i+JwYyAdF0gKXwKx0uxbkBTsmm2M+0MDusohQdFLoEIkSIFktXBIDefoa7iGpLKRfG2VsZLpwJgnvnD0HqbnuR+k+W+bu7BHt4CAaR6GTllsDCjyq9zNyhUThzSnf2WNIpOEF5kHspZlbGfawURuUJH/U="
     - secure: "jqVpmWxxBVXu2X8+XJMpKH0cooc2EKz9xKL2znBfYdNafJORSXcFAVbjCX5mZmVDcgIMwDtm2+gIG4P73hzJ2e3S+y2Z9ROJGyXHa3AxUTvXHQsxqzH8coHHqB8vTvfr0t2O5aKfpvpICpSea39r0hzNoMv6Ie5SwBdqj1YY9K0="
   matrix:
+    - NODE_VERSION="v11"
     - NODE_VERSION="v10"
     - NODE_VERSION="v9"
     - NODE_VERSION="v8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsevents",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Native Access to Mac OS-X FSEvents",
   "main": "fsevents.js",
   "dependencies": {


### PR DESCRIPTION
As per https://github.com/strongloop/fsevents/issues/244#issuecomment-452984328

Why not, releasing NAPI will take until April, until then we'll just get complaints.