### PR TITLE
Only support v1.x until node-v11.x use v2.x after that

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ env:
     - NODE_VERSION="v6"
     - NODE_VERSION="v5"
     - NODE_VERSION="v4"
-    - NODE_VERSION="v0.10"
 
 before_install:
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "darwin"
   ],
   "engines": {
-    "node": ">=0.8.0"
+    "node": ">=4 <=11"
   },
   "scripts": {
     "install": "node install",


### PR DESCRIPTION
At some point we'll want to drop support for newer node versions in combination with fsevents@1.x 

I think this should be with node v12.x being no longer supported especially since we have the NAPI version ready to go.

- [x] Release fsevents@2.x
- [x] Update chokidar to use v2.x
- [ ] Notify other dependents of the update 